### PR TITLE
BfresStructs: Remove extra variable assignment when renaming FMAT

### DIFF
--- a/Switch_FileFormatsMain/FileFormats/BFRES/BfresStructs.cs
+++ b/Switch_FileFormatsMain/FileFormats/BFRES/BfresStructs.cs
@@ -1712,8 +1712,6 @@ namespace Bfres.Structs
 
             if (dialog.ShowDialog() == DialogResult.OK)
             {
-                Text = dialog.textBox1.Text;
-
                 ((FMDL)Parent.Parent).materials.Remove(Text);
                 Text = dialog.textBox1.Text;
                 ((FMDL)Parent.Parent).materials.Add(Text, this);


### PR DESCRIPTION
Fixes renaming materials.