### PR TITLE
BFRES: Add missing samplers to the sampler list instead of attributes

### DIFF
--- a/Switch_FileFormatsMain/FileFormats/BFRES.cs
+++ b/Switch_FileFormatsMain/FileFormats/BFRES.cs
@@ -236,7 +236,7 @@ namespace FirstPlugin
             foreach (var tex in shape.GetMaterial().textures)
             {
                 if (!shd.samplers.ContainsValue(tex.SamplerName))
-                    shd.attributes.Add(tex.SamplerName, tex.SamplerName);
+                    shd.samplers.Add(tex.SamplerName, tex.SamplerName);
             }
         }
 


### PR DESCRIPTION
Somehow got this bug to trigger - I'm not 100% sure how.