### PR TITLE
Fix PAC archive file naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ In the event that the tool cannot compile, check references. All the libraries a
 - Sage of Mirrors for SuperBMDLib. 
 - Ambrosia for BTI and TXE support.
 - Kuriimu for some IO and file parsing help
+- Skyth and Radfordhound for PAC documentation
 
 ##  Resources
 - [Treeview Icons by icons8](https://icons8.com/)

--- a/Toolbox/GUI/Credits.resx
+++ b/Toolbox/GUI/Credits.resx
@@ -127,6 +127,7 @@
 - Syroot for helpful IO extensions and libraies
 - GDK Chan for some DDS decode methods
 - AboodXD for BNTX texture swizzling
-- MelonSpeedruns for logo.</value>
+- MelonSpeedruns for logo.
+- Skyth and Radfordhound for PAC documentation</value>
   </data>
 </root>


### PR DESCRIPTION
This PR fixes how PAC file entry names were parsed. The nodes are no longer treated as directories.

I also updated the credits to include myself and @Radfordhound.