### PR TITLE
Add support for exporting Wii U FMAT materials as Wii MDL0mat files

### DIFF
--- a/BrawlboxHelper/BrawlboxHelper.csproj
+++ b/BrawlboxHelper/BrawlboxHelper.csproj
@@ -22,6 +22,8 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -34,7 +36,6 @@
   <ItemGroup>
     <Reference Include="BrawlLib">
       <HintPath>..\Toolbox\Lib\BrawlLib.dll</HintPath>
-      <Private>False</Private>
     </Reference>
     <Reference Include="Gl_EditorFramework">
       <HintPath>..\Toolbox\Gl_EditorFramework.dll</HintPath>

--- a/File_Format_Library/File_Format_Library.csproj
+++ b/File_Format_Library/File_Format_Library.csproj
@@ -563,6 +563,12 @@
     <Compile Include="GUI\BCH\MetaData\UserDataParser.Designer.cs">
       <DependentUpon>UserDataParser.cs</DependentUpon>
     </Compile>
+    <Compile Include="GUI\BFRES\Materials\MDL0MaterialExportDialog.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="GUI\BFRES\Materials\MDL0MaterialExportDialog.Designer.cs">
+      <DependentUpon>MDL0MaterialExportDialog.cs</DependentUpon>
+    </Compile>
     <Compile Include="GUI\BXFNT\CharacterSelector.cs">
       <SubType>UserControl</SubType>
     </Compile>
@@ -1724,6 +1730,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="GUI\BCH\MetaData\UserDataParser.resx">
       <DependentUpon>UserDataParser.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="GUI\BFRES\Materials\MDL0MaterialExportDialog.resx">
+      <DependentUpon>MDL0MaterialExportDialog.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="GUI\BXFNT\CharacterSelector.resx">
       <DependentUpon>CharacterSelector.cs</DependentUpon>

--- a/File_Format_Library/GUI/BFRES/Materials/MDL0MaterialExportDialog.Designer.cs
+++ b/File_Format_Library/GUI/BFRES/Materials/MDL0MaterialExportDialog.Designer.cs
@@ -1,0 +1,151 @@
+﻿namespace FirstPlugin.GUI.BFRES.Materials
+{
+    partial class MDL0MaterialExportDialog
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.albCheckBox = new Toolbox.Library.Forms.STCheckBox();
+            this.emmCheckBox = new Toolbox.Library.Forms.STCheckBox();
+            this.bake0CheckBox = new Toolbox.Library.Forms.STCheckBox();
+            this.bake1CheckBox = new Toolbox.Library.Forms.STCheckBox();
+            this.btnConfirm = new Toolbox.Library.Forms.STButton();
+            this.btnCancel = new Toolbox.Library.Forms.STButton();
+            this.contentContainer.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // contentContainer
+            // 
+            this.contentContainer.Controls.Add(this.btnCancel);
+            this.contentContainer.Controls.Add(this.btnConfirm);
+            this.contentContainer.Controls.Add(this.bake1CheckBox);
+            this.contentContainer.Controls.Add(this.bake0CheckBox);
+            this.contentContainer.Controls.Add(this.emmCheckBox);
+            this.contentContainer.Controls.Add(this.albCheckBox);
+            this.contentContainer.Location = new System.Drawing.Point(0, 0);
+            this.contentContainer.Size = new System.Drawing.Size(251, 207);
+            this.contentContainer.Controls.SetChildIndex(this.albCheckBox, 0);
+            this.contentContainer.Controls.SetChildIndex(this.emmCheckBox, 0);
+            this.contentContainer.Controls.SetChildIndex(this.bake0CheckBox, 0);
+            this.contentContainer.Controls.SetChildIndex(this.bake1CheckBox, 0);
+            this.contentContainer.Controls.SetChildIndex(this.btnConfirm, 0);
+            this.contentContainer.Controls.SetChildIndex(this.btnCancel, 0);
+            // 
+            // albCheckBox
+            // 
+            this.albCheckBox.AutoSize = true;
+            this.albCheckBox.Checked = true;
+            this.albCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.albCheckBox.Location = new System.Drawing.Point(39, 49);
+            this.albCheckBox.Name = "albCheckBox";
+            this.albCheckBox.Size = new System.Drawing.Size(125, 17);
+            this.albCheckBox.TabIndex = 0;
+            this.albCheckBox.Text = "Include Diffuse maps";
+            this.albCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // emmCheckBox
+            // 
+            this.emmCheckBox.AutoSize = true;
+            this.emmCheckBox.Checked = true;
+            this.emmCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.emmCheckBox.Location = new System.Drawing.Point(39, 73);
+            this.emmCheckBox.Name = "emmCheckBox";
+            this.emmCheckBox.Size = new System.Drawing.Size(133, 17);
+            this.emmCheckBox.TabIndex = 1;
+            this.emmCheckBox.Text = "Include Emission maps";
+            this.emmCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // bake0CheckBox
+            // 
+            this.bake0CheckBox.AutoSize = true;
+            this.bake0CheckBox.Checked = true;
+            this.bake0CheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.bake0CheckBox.Location = new System.Drawing.Point(39, 97);
+            this.bake0CheckBox.Name = "bake0CheckBox";
+            this.bake0CheckBox.Size = new System.Drawing.Size(155, 17);
+            this.bake0CheckBox.TabIndex = 2;
+            this.bake0CheckBox.Text = "Include Shadow bakemaps";
+            this.bake0CheckBox.UseVisualStyleBackColor = true;
+            // 
+            // bake1CheckBox
+            // 
+            this.bake1CheckBox.AutoSize = true;
+            this.bake1CheckBox.Checked = true;
+            this.bake1CheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.bake1CheckBox.Location = new System.Drawing.Point(39, 121);
+            this.bake1CheckBox.Name = "bake1CheckBox";
+            this.bake1CheckBox.Size = new System.Drawing.Size(139, 17);
+            this.bake1CheckBox.TabIndex = 3;
+            this.bake1CheckBox.Text = "Include Light bakemaps";
+            this.bake1CheckBox.UseVisualStyleBackColor = true;
+            // 
+            // btnConfirm
+            // 
+            this.btnConfirm.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnConfirm.Location = new System.Drawing.Point(39, 149);
+            this.btnConfirm.Name = "btnConfirm";
+            this.btnConfirm.Size = new System.Drawing.Size(75, 23);
+            this.btnConfirm.TabIndex = 4;
+            this.btnConfirm.Text = "Export";
+            this.btnConfirm.UseVisualStyleBackColor = false;
+            this.btnConfirm.Click += new System.EventHandler(this.btnConfirm_Click);
+            // 
+            // btnCancel
+            // 
+            this.btnCancel.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.btnCancel.Location = new System.Drawing.Point(137, 149);
+            this.btnCancel.Name = "btnCancel";
+            this.btnCancel.Size = new System.Drawing.Size(75, 23);
+            this.btnCancel.TabIndex = 5;
+            this.btnCancel.Text = "Cancel";
+            this.btnCancel.UseVisualStyleBackColor = false;
+            this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
+            // 
+            // MDL0MaterialExportDialog
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(251, 206);
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "MDL0MaterialExportDialog";
+            this.Text = "Export options";
+            this.contentContainer.ResumeLayout(false);
+            this.contentContainer.PerformLayout();
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private Toolbox.Library.Forms.STCheckBox albCheckBox;
+        private Toolbox.Library.Forms.STCheckBox emmCheckBox;
+        private Toolbox.Library.Forms.STCheckBox bake0CheckBox;
+        private Toolbox.Library.Forms.STCheckBox bake1CheckBox;
+        private Toolbox.Library.Forms.STButton btnConfirm;
+        private Toolbox.Library.Forms.STButton btnCancel;
+    }
+}

--- a/File_Format_Library/GUI/BFRES/Materials/MDL0MaterialExportDialog.cs
+++ b/File_Format_Library/GUI/BFRES/Materials/MDL0MaterialExportDialog.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using Toolbox.Library.Forms;
+
+namespace FirstPlugin.GUI.BFRES.Materials
+{
+    public partial class MDL0MaterialExportDialog : STForm
+    {
+        String ExportFlags = "UNSET";
+
+        public MDL0MaterialExportDialog()
+        {
+            InitializeComponent();
+        }
+
+        public String GetExportFlags()
+        {            
+            return ExportFlags;
+        }
+
+        private void btnCancel_Click(object sender, EventArgs e)
+        {
+            ExportFlags = "UNSET";
+            this.Close();
+        }
+
+        private void btnConfirm_Click(object sender, EventArgs e)
+        {
+            String output = "";
+            if (albCheckBox.Checked)
+            {
+                output += "A";
+            }
+            if (emmCheckBox.Checked)
+            {
+                output += "E";
+            }
+            if (bake0CheckBox.Checked)
+            {
+                output += "S";
+            }
+            if (bake1CheckBox.Checked)
+            {
+                output += "L";
+            }
+            ExportFlags = output;
+            this.Close();
+        }
+    }
+}

--- a/File_Format_Library/GUI/BFRES/Materials/MDL0MaterialExportDialog.resx
+++ b/File_Format_Library/GUI/BFRES/Materials/MDL0MaterialExportDialog.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>


### PR DESCRIPTION
This code uses BrawlLib to export supported parameters of FMAT materials as MDL0 material nodes.
In general, this adds:
- A new format option to the single and batch material export dialog to output .mdl0mat files for use with BrawlCrate/BrawlBox.
- Another dialog to allow customization of which texture references to include in the output material.
- MaterialPrototype, a middleman class to transfer between File_Format_Library and BrawlHelper; this is because we can't use FMAT in BrawlHelper (recursive dependency) and MDL0MaterialNode (from BrawlLib) can't be used in File_Format_Library as referencing BrawlLib.dll results in ambiguous declarations in already present working code.
- Some copy pasted code from BrawlLib changed to fix arithmetic overflow exceptions caused by dumb BrawlLib using 32-bit void pointers in 2020.
- The exporter (As a BrawlHelper converter), which converts most shared attributes of Wii U materials to Wii equivalents.

The exporter currently brings over:
- Albedo and Emission texture references (support for Specular maps can be added, but most NW4R games don't use them, except for MSLOG12; Normal mapping is unsupported by the Wii's TEV, except for indirect textures which use a different normal map format than the Wii U - hence the exclusion)
- Shadow and Light bakemap references. Those vary from game to game and sometimes have to be converted to split I8 images (the example of this is Mario Kart 8 bakemaps, which use the Red channel for AO and Green for Shadows - to make them work with the Wii, they have to be exported as two I8 textures with the I channel set to R or G respectively).
- Mario Kart 8 (and other gsys renderer-based games, possibly Splatoon) bake coordinates adjusted through some simple equations to match the Wii's coordinate and scaling system. This allows the textures mentioned earlier to be used on Wii models as they are on the Wii U.
- Alpha Testing, Blending, Face culling and texture filtering parameters.

Although most of the Wii U's shading capabilities aren't present on the Wii's fixed function GPU, this exporter facilitates f. e. backporting custom tracks from Mario Kart 8 to MKWii as it automatically includes texture references and converted bake coordinates in the final material binary.

This PR currently does not feature support for exporting Nintendo Switch BFRES materials - the code retrieves certain parameters from the BFRES library's RenderState which aren't present in the shared STGenericMat implementation, hence Syroot's original classes have to be used. Unfortunately, those libraries have separate codebases for Wii U and Switch, which is why only Wii U material support is currently present.