### PR TITLE
Better Zlib GZip compression

### DIFF
--- a/Switch_Toolbox_Library/Compression/STLibraryCompression.cs
+++ b/Switch_Toolbox_Library/Compression/STLibraryCompression.cs
@@ -158,7 +158,10 @@ namespace Toolbox.Library.IO
                     section_sizes = new uint[sectionCount];
                     for (int i = 0; i < sectionCount; i++)
                     {
-                        byte[] chunk = ZLIB.Compress(reader.ReadBytes(0x10000));
+                        var encoding = new ZlibCodec();
+                        encoding.InitializeDeflate(CompressionLevel.BestCompression);
+                        byte[] chunk = ZlibStream.CompressBuffer(reader.ReadBytes(0x10000));
+                        encoding.EndDeflate();
 
                         section_sizes[i] = (uint)chunk.Length;
 

--- a/Switch_Toolbox_Library/Compression/STLibraryCompression.cs
+++ b/Switch_Toolbox_Library/Compression/STLibraryCompression.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System;
 using System.Runtime.InteropServices;
+using using Ionic.Zlib;
 
 namespace Toolbox.Library.IO
 {


### PR DESCRIPTION
I attached the dependency below, or you can just download the [library](https://www.nuget.org/packages/DotNetZip/). I left the zlib compression function you used @ line 226 because I literally just copied the code I had and pasted it on Github's editor, so I don't know if there's any other references to that function. If I forgot something or wanted a look, you can look at this [GZip.zip](https://github.com/KillzXGaming/Switch-Toolbox/files/4625117/GZip.zip)

[DotNetZip.zip](https://github.com/KillzXGaming/Switch-Toolbox/files/4625093/DotNetZip.zip)
