### PR TITLE
Fix Generate Mipmaps

### DIFF
--- a/Switch_Toolbox_Library/Generics/Texture/GenericTexture.cs
+++ b/Switch_Toolbox_Library/Generics/Texture/GenericTexture.cs
@@ -745,7 +745,7 @@ namespace Toolbox.Library
 
         public uint GenerateMipCount(uint Width, uint Height)
         {
-            uint MipmapNum = 0;
+            uint MipmapNum = 1;
             uint num = Math.Max(Width, Height);
 
             int width = (int)Width;


### PR DESCRIPTION
Corrects GenerateMipCount to start from 1 instead of from 0.