### PR TITLE
Fix a crash occurring when converting YAML to BYAML

### DIFF
--- a/File_Format_Library/FileFormats/Byaml/YamlByamlConverter.cs
+++ b/File_Format_Library/FileFormats/Byaml/YamlByamlConverter.cs
@@ -77,7 +77,7 @@ namespace FirstPlugin
 
             var data = new ByamlExt.Byaml.BymlFileData();
             var yaml = new YamlStream();
-            yaml.Load(new StringReader(text));
+            yaml.Load(File.OpenText(text));
             var mapping = (YamlMappingNode)yaml.Documents[0].RootNode;
 
             foreach (var child in mapping.Children)


### PR DESCRIPTION
Previously, line [80](https://github.com/KillzXGaming/Switch-Toolbox/blob/d923705c3cb9343293d7e340f88db39f05080bef/File_Format_Library/FileFormats/Byaml/YamlByamlConverter.cs#L80) could cause the following crash:
![image](https://user-images.githubusercontent.com/70081529/114185751-4ebea280-9903-11eb-9c5e-e19cd20c69a2.png)
_Yes I used this code on a Console Application it was for good measure_
I have fixed this error by changing line 80 to be `yaml.Load(File.OpenText(text));` because somehow the stream created by File.OpenText is better than a new StringReader. 