### PR TITLE
Avoid using LINQ for array slicing

### DIFF
--- a/Switch_Toolbox_Library/Util/Util.cs
+++ b/Switch_Toolbox_Library/Util/Util.cs
@@ -175,7 +175,7 @@ namespace Toolbox.Library
 
         public static byte[] SubArray(byte[] data, uint offset, uint length)
         {
-            return data.Skip((int)offset).Take((int)length).ToArray();
+            return data.Slice(offset, length);
         }
 
         public static string RenameDuplicateString(List<string> strings, string oldString, int index = 0, int numDigits = 1)


### PR DESCRIPTION
Using LINQ is quite slow compared to standard array operations. It's possible to optimize this even further to avoid the copy completely, but that would require making some adjustments to existing code. In newer versions of .NET, this can be accomplished with Span<T>. For .NET Framework, the performance might be similar to Span<T> with [ArraySegment\<T\>]( https://docs.microsoft.com/en-us/dotnet/api/system.arraysegment-1?view=netframework-4.6.2).

This is the improvement I'm getting when performing CPU sampling in release mode for opening `/campaign/campaignmap/normal/model/bg_final/bg_main_final_col.nutexb`. The image size is 36044800. Left is before and right is after the change.
![image](https://user-images.githubusercontent.com/23301691/135013125-fb1049a9-3e93-4c34-9eed-681dd186fb31.png)
