### PR TITLE
Fix #349 : batch exportation of pokemon models

### DIFF
--- a/File_Format_Library/FileFormats/Pokemon/GFLX/GFBMDL/GFBMDL.cs
+++ b/File_Format_Library/FileFormats/Pokemon/GFLX/GFBMDL/GFBMDL.cs
@@ -16,7 +16,7 @@ using Newtonsoft.Json;
 
 namespace FirstPlugin
 {
-    public class GFBMDL : TreeNodeFile, IContextMenuNode, IFileFormat
+    public class GFBMDL : TreeNodeFile, IContextMenuNode, IFileFormat, IExportableModel
     {
         public FileType FileType { get; set; } = FileType.Model;
 
@@ -760,6 +760,28 @@ namespace FirstPlugin
         public void Unload()
         {
 
+        }
+
+        public IEnumerable<STGenericObject> ExportableMeshes => Model.GenericMeshes;
+        public IEnumerable<STGenericMaterial> ExportableMaterials => Model.GenericMaterials;
+        public IEnumerable<STGenericTexture> ExportableTextures => TextureList;
+        public STSkeleton ExportableSkeleton => Model.Skeleton;
+
+        public List<STGenericTexture> TextureList
+        {
+            get
+            {
+                //Export all textures that use the same archive
+                List<STGenericTexture> textures = new List<STGenericTexture>();
+                foreach (var bntx in PluginRuntime.bntxContainers)
+                    foreach (var tex in bntx.Textures.Values)
+                    {
+                        if (Model.Textures.Contains(tex.Text))
+                            textures.Add(tex);
+                    }
+                
+                return textures;
+            }
         }
     }
 }


### PR DESCRIPTION
Pokemon files in Pokemon Sword and Shield were not impacted by Batch Export because GFBMDL did not inherit IExportableModel, so the program considered that there was nothing to export. I did not try for Animal Crossing or Pokemon Let's Go, but the solution may be similar, depending on what file format you want

There is a bit of repetition with the ExportModel function, maybe we can simplify it though :
https://github.com/KillzXGaming/Switch-Toolbox/blob/849aa7f6c2d91061d5b7e47afbc9e4370aaf8ba3/File_Format_Library/FileFormats/Pokemon/GFLX/GFBMDL/GFBMDL.cs#L744