### PR TITLE
Fix file names with slashes

### DIFF
--- a/File_Format_Library/FileFormats/NLG/LM3/LM3_Model.cs
+++ b/File_Format_Library/FileFormats/NLG/LM3/LM3_Model.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -63,7 +64,9 @@ namespace FirstPlugin.LuigisMansion3
 
                 settings.SuppressConfirmDialog = true;
 
-                DAE.Export($"{folderPath}/{mdl.Text}.dae", settings, model, new List<STGenericTexture>());
+                if (mdl.Text.Contains("/"))
+                    Directory.CreateDirectory($"{folderPath}/{Path.GetDirectoryName(mdl.Text)}");
+                DAE.Export($"{folderPath}/{mdl.Text.Replace("/", "//")}.dae", settings, model, new List<STGenericTexture>());
             }
 
             System.Windows.Forms.MessageBox.Show($"Exported models Successfuly!");


### PR DESCRIPTION
In Luigi's Manson 3, some of the archived models have slashes in their names. This means that they can't be exported with those names, and Toolbox will crash when it reaches them, if you try to "export all".

What i have done to fix this, is make toolbox treat names with slashes as directory paths, with a file name on the end.