### PR TITLE
BCLAN: Fix writing of PAI1 section

### DIFF
--- a/File_Format_Library/FileFormats/Layout/CTR/BCLAN.cs
+++ b/File_Format_Library/FileFormats/Layout/CTR/BCLAN.cs
@@ -313,9 +313,10 @@ namespace LayoutBXLYT
                     writer.Write(new uint[Textures.Count]);
                     for (int i = 0; i < Textures.Count; i++)
                     {
-                        writer.WriteUint32Offset(startOfsPos + (i * 4), startPos);
+                        writer.WriteUint32Offset(startOfsPos + (i * 4), startOfsPos);
                         writer.WriteString(Textures[i]);
                     }
+                    writer.Align(4);
                 }
                 if (Entries.Count > 0)
                 {


### PR DESCRIPTION
Fixes writing of PAI1 section in BCLAN files (tested with Mario Kart 7 bclan files):
1. The offset of the strings is relative to the start of the table, not the start of the PAI1 section.
2. 4 bytes of padding after the strings are needed for proper alignment of the rest of the section.