### PR TITLE
Kirby and the Forgotten Land ZSTD support

### DIFF
--- a/Switch_Toolbox_Library/Compression/CompressionMenus.cs
+++ b/Switch_Toolbox_Library/Compression/CompressionMenus.cs
@@ -27,6 +27,7 @@ namespace Toolbox.Library.IO
             items.Add(CreateMenu("lZ4"));
             items.Add(CreateMenu("lZ4F"));
             items.Add(CreateMenu("ZSTD"));
+            items.Add(CreateMenu("ZSTD (Kirby)"));
             items.Add(CreateMenu("ZLIB"));
             items.Add(CreateMenu("ZLIB_GZ (Hyrule Warriors)"));
             return items;
@@ -82,6 +83,8 @@ namespace Toolbox.Library.IO
                 OpenFileForCompression(new LZ4F(), Compress);
             else if (Name == "ZSTD")
                 OpenFileForCompression(new Zstb(), Compress);
+            else if (Name == "ZSTD (Kirby)")
+                OpenFileForCompression(new Zstb_Kirby(), Compress);
             else if (Name == "ZLIB")
                 OpenFileForCompression(new Zlib(), Compress);
             else if (Name.Contains("ZLIB_GZ"))

--- a/Switch_Toolbox_Library/Compression/Formats/Zstb_Kirby.cs
+++ b/Switch_Toolbox_Library/Compression/Formats/Zstb_Kirby.cs
@@ -9,12 +9,12 @@ using K4os.Compression.LZ4.Streams;
 
 namespace Toolbox.Library
 {
-    public class LZ4F : ICompressionFormat
+    public class Zstb_Kirby : ICompressionFormat
     {
-        public string[] Description { get; set; } = new string[] { "LZ4F Compression" };
-        public string[] Extension { get; set; } = new string[] { "*.cmp", "*.cmpbin", "*.lz4f" };
+        public string[] Description { get; set; } = new string[] { "ZSTD Compression (Kirby)" };
+        public string[] Extension { get; set; } = new string[] { "*.cmp" };
 
-        public override string ToString() { return "LZ4F"; }
+        public override string ToString() { return "ZSTD (Kirby)"; }
 
         public bool Identify(Stream stream, string fileName)
         {
@@ -25,9 +25,9 @@ namespace Toolbox.Library
                 uint DecompressedSize = reader.ReadUInt32();
                 uint magicCheck = reader.ReadUInt32();
 
-                bool LZ4FDefault = magicCheck == 0x184D2204;
+                bool ZSTDDefault = magicCheck == 0xFD2FB528;
 
-                return LZ4FDefault;
+                return ZSTDDefault;
             }
         }
 
@@ -40,7 +40,7 @@ namespace Toolbox.Library
                 reader.Position = 0;
                 int OuSize = reader.ReadInt32();
                 int InSize = (int)stream.Length - 4;
-                var dec = STLibraryCompression.Type_LZ4F.Decompress(reader.getSection(4, InSize));
+                var dec = Zstb.SDecompress(reader.getSection(4, InSize));
                 return new MemoryStream(dec);
             }
         }
@@ -51,8 +51,7 @@ namespace Toolbox.Library
             using (var writer = new FileWriter(mem, true))
             {
                 writer.Write((uint)stream.Length);
-                byte[] buffer = LZ4.Frame.LZ4Frame.Compress(stream,
-                    LZ4.Frame.LZ4MaxBlockSize.MB1, true, true, false, true, false);
+                byte[] buffer = Zstb.SCompress(stream.ToArray());
 
                 writer.Write(buffer, 0, buffer.Length);
             }

--- a/Switch_Toolbox_Library/Format Managers/FormatList.cs
+++ b/Switch_Toolbox_Library/Format Managers/FormatList.cs
@@ -32,6 +32,7 @@ namespace Toolbox.Library
             Formats.Add(typeof(Zlib));
             Formats.Add(typeof(ZlibGZ));
             Formats.Add(typeof(Zstb));
+            Formats.Add(typeof(Zstb_Kirby));
             Formats.Add(typeof(MtaCustomCmp));
             Formats.Add(typeof(LZ77));
 

--- a/Switch_Toolbox_Library/Toolbox_Library.csproj
+++ b/Switch_Toolbox_Library/Toolbox_Library.csproj
@@ -238,6 +238,7 @@
     <Compile Include="Compression\Formats\MtaCustomCmp.cs" />
     <Compile Include="Compression\Formats\ZlibGZ.cs" />
     <Compile Include="Compression\Formats\Zstb.cs" />
+    <Compile Include="Compression\Formats\Zstb_Kirby.cs" />
     <Compile Include="Compression\LZ77_WII.cs" />
     <Compile Include="Compression\7ZIP\LZMA\LzmaBase.cs" />
     <Compile Include="Compression\7ZIP\LZMA\LzmaDecoder.cs" />


### PR DESCRIPTION
KatFL uses the same structure as LZ4F in the previous Switch Kirby games (decompressed size at the top of the file before the data), but with the data being ZSTD compressed instead.