### PR TITLE
BFLAN: Fix writing of PAT1 and PAI1 section

### DIFF
--- a/File_Format_Library/FileFormats/Layout/CAFE/BFLAN.cs
+++ b/File_Format_Library/FileFormats/Layout/CAFE/BFLAN.cs
@@ -263,6 +263,8 @@ namespace LayoutBXLYT
                 writer.WriteUint32Offset(startPos + 16, startPos);
                 for (int i = 0; i < Groups.Count; i++)
                     writer.WriteString(Groups[i], 28);
+            
+                writer.Align(4);
             }
         }
 
@@ -330,6 +332,7 @@ namespace LayoutBXLYT
                         writer.WriteUint32Offset(startOfsPos + (i * 4), startOfsPos);
                         writer.WriteString(Textures[i]);
                     }
+                    writer.Align(4);
                 }
                 if (Entries.Count > 0)
                 {


### PR DESCRIPTION
Heavily inspired of pull request #459 

- This fixes the issue i had with the "unaligned access" exception on the console