### PR TITLE
Null check data in bflyt writer

### DIFF
--- a/File_Format_Library/FileFormats/Layout/CAFE/USD1.cs
+++ b/File_Format_Library/FileFormats/Layout/CAFE/USD1.cs
@@ -34,8 +34,10 @@ namespace LayoutBXLYT.Cafe
             long startPos = writer.Position - 8;
 
             if (!Edited) {
-                writer.Write(this.Data);
-                return;
+                if (Data != null) {
+                    writer.Write(this.Data);
+                    return;
+                }
             }
 
             writer.Write((ushort)Entries.Count);


### PR DESCRIPTION
Fixed null value error when saving some BFLYT files. There is probably a better way to fix this, like settings `this.Data` (the null value in question) to the read data. But I didn't feel like looking into it that far, and this seemed to work (even if it is a bit slower).