### PR TITLE
don't pad nutexb files by default

### DIFF
--- a/Switch_Toolbox_Library/Runtime.cs
+++ b/Switch_Toolbox_Library/Runtime.cs
@@ -75,7 +75,7 @@ namespace Toolbox.Library
         public class NUTEXBSettings
         {
             public static bool LimitFileSize = false;
-            public static bool PadFileSize = true;
+            public static bool PadFileSize = false;
         }
 
         public class MessageEditor


### PR DESCRIPTION
Most users are loading mods for Smash Ultimate using arcropolis, so padding isn't necessary. This greatly reduces the download size of mods, especially when users start with 4k textures and try to downscale them to 2k or 1k.