### PR TITLE
Fixes for TRPAK implementation

### DIFF
--- a/File_Format_Library/FileFormats/Archives/TRPAK/TRPAK.cs
+++ b/File_Format_Library/FileFormats/Archives/TRPAK/TRPAK.cs
@@ -31,6 +31,7 @@ namespace FirstPlugin
                     { ".trmsh", "Models" },
                     { ".trmtr", "Models" },
                     { ".trskl", "Models" },
+                    { ".tranm", "Animations" },
                 };
             }
         }
@@ -142,6 +143,8 @@ namespace FirstPlugin
                         folder = new TextureFolder(this, "Textures");
                     if (folderName == "Models")
                         folder = new GFPAK.QuickAccessFileFolder("Models");
+                    if (folderName == "Animations")
+                        folder = new GFPAK.QuickAccessFileFolder("Animations");
 
                     node.Nodes.Add(folder);
                     folders.Add(folderName, folder);
@@ -198,7 +201,7 @@ namespace FirstPlugin
             {
                 fileFormat.FileName = FileName;
 
-                if (fileFormat.Identify(new MemoryStream(f)))
+                if (fileFormat.Identify(new MemoryStream(f)) && fileFormat.GetType() != typeof(GFBMDL))
                 {
                     return fileFormat.Extension[0].Replace("*", "");
                 }
@@ -243,7 +246,7 @@ namespace FirstPlugin
             {
                 if (fileHashName != "")
                 {
-                    return $"{fileHashName}{ext}";
+                    return $"{fileHashName}";
                 }
                 else
                     return $"{fileHash.ToString("X")}{ext}";


### PR DESCRIPTION
- Fix wrong detection of GFMDL files. won't be detected as Fileformat because that Fileformat is not used in those archives but because it is a Flatbuffer File Format other Files get confused for it sometimes.
- Don't add the detected file extension to known file names. 
- Added Quick Access folder for .tranm files for feature parity with GFPAK.