### PR TITLE
workaround for exporting tranm Files

### DIFF
--- a/File_Format_Library/FileFormats/Archives/TRPAK/TRPAK.cs
+++ b/File_Format_Library/FileFormats/Archives/TRPAK/TRPAK.cs
@@ -144,7 +144,7 @@ namespace FirstPlugin
                     if (folderName == "Models")
                         folder = new GFPAK.QuickAccessFileFolder("Models");
                     if (folderName == "Animations")
-                        folder = new GFPAK.QuickAccessFileFolder("Animations");
+                        folder = new GFPAK.AnimationFolder("Animations");
 
                     node.Nodes.Add(folder);
                     folders.Add(folderName, folder);

--- a/File_Format_Library/FileFormats/Pokemon/Trinity/TRANM/TRANM.cs
+++ b/File_Format_Library/FileFormats/Pokemon/Trinity/TRANM/TRANM.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Toolbox.Library;
+using Toolbox.Library.Animations;
+
+namespace FirstPlugin
+{
+    internal class TRANM : GFBANM, IFileFormat, IAnimationContainer, IConvertableTextFormat
+    {
+        public new bool Identify(System.IO.Stream stream)
+        {
+            return Utils.GetExtension(FileName) == ".tranm";
+        }
+    }
+}

--- a/File_Format_Library/File_Format_Library.csproj
+++ b/File_Format_Library/File_Format_Library.csproj
@@ -485,6 +485,7 @@
     <Compile Include="FileFormats\Pokemon\GFLX\GFBMDL\GFMDLStructs.cs" />
     <Compile Include="FileFormats\Pokemon\GFLX\GFBPMCATALOG\FlatBuffers\gfbpmcatalog.cs" />
     <Compile Include="FileFormats\Pokemon\GFLX\PokemonTable.cs" />
+    <Compile Include="FileFormats\Pokemon\Trinity\TRANM\TRANM.cs" />
     <Compile Include="FileFormats\Rom\3DS\NCSDStructs.cs" />
     <Compile Include="FileFormats\Rom\3DS\NCSD.cs" />
     <Compile Include="FileFormats\Rom\3DS\RomFS.cs" />

--- a/File_Format_Library/Main.cs
+++ b/File_Format_Library/Main.cs
@@ -461,6 +461,7 @@ namespace FirstPlugin
             Formats.Add(typeof(MTXT));
             Formats.Add(typeof(NKN));
             Formats.Add(typeof(MetroidDreadLibrary.BSMAT));
+            Formats.Add(typeof(TRANM));
 			
             //Formats.Add(typeof(XLINK_FILE));
 


### PR DESCRIPTION
tranm and gfbanm are structurally the same. so this allows exporting them without completely reimplementing what is essentially the same file format. together with the right skeleton, this allows Exporting the animations in a usable format.
this also adds the ability to Export all Animations at once to gain even more feature parity with the gfpak implementation.