### PR TITLE
Don't delete the user's hashes folder on update

### DIFF
--- a/Updater/Program.cs
+++ b/Updater/Program.cs
@@ -90,8 +90,12 @@ namespace Updater
 
                 string dirName = new DirectoryInfo(dir).Name;
 
-                if (Directory.Exists(Path.Combine(folderDir, dirName + @"\")))
+                if (!dirName.Equals("Hashes", StringComparison.CurrentCultureIgnoreCase) // Let's keep the users custom hashes in tact
+                    && Directory.Exists(Path.Combine(folderDir, dirName + @"\")))
+                {
                     Directory.Delete(Path.Combine(folderDir, dirName + @"\"), true);
+                }
+
                 Directory.Move(dir, Path.Combine(folderDir, dirName + @"\"));
             }
             foreach (string file in Directory.GetFiles("master/"))


### PR DESCRIPTION
It's rather annoying that I need to keep an extra copy of all my hashes because updater keeps deleting all of them.

This change will keep the contents of the user's folder and still allow overwriting of the files included on the mast branch