### PR TITLE
Remove file extension when decompressing files with multiple extensions

### DIFF
--- a/Switch_Toolbox_Library/Compression/CompressionMenus.cs
+++ b/Switch_Toolbox_Library/Compression/CompressionMenus.cs
@@ -113,7 +113,7 @@ namespace Toolbox.Library.IO
             if (fileNames.Length == 0)
                 return;
 
-            string ext = Compress ? ".comp" : ".dec";
+            string ext = Compress ? ".comp" : "";
             if (compressionFormat.Extension.Length > 0 && Compress)
                 ext = compressionFormat.Extension[0].Replace("*", string.Empty);
 
@@ -167,6 +167,7 @@ namespace Toolbox.Library.IO
             {
                 SaveFileDialog sfd = new SaveFileDialog();
                 string name = Path.GetFileName(fileNames[0]);
+                name = name.Count(c => c == '.') > 1 && !Compress ? name.Remove(name.LastIndexOf('.')) : name;
                 sfd.FileName = name + ext;
                 sfd.Filter = "All files(*.*)|*.*";
 


### PR DESCRIPTION
This pull request updates the `SaveFileForCompression` method to remove the file extension when decompressing files that have multiple extensions. Previously, the method would add a ".dec" extension to the file name when decompressing a file. For example, a file named "WorldMap.msbt.lz" would be saved as "WorldMap.msbt.dec" after being decompressed.

With this change, the method will now remove the original file extension when decompressing a file that has multiple extensions. For example, a file named "WorldMap.msbt.lz" will be saved as "WorldMap.msbt" after being decompressed. However, if a file has only one extension (e.g. "whatnot.compress"), its name will remain unchanged.

The following changes were made to the code:

- The line that defines the `ext` variable was changed from:
```csharp
string ext = Compress ? ".comp" : ".dec";
```
to:
```csharp
string ext = Compress ? ".comp" : "";
```
to remove the ".dec" extension when decompressing a file.

- The following line was added to remove the original file extension when decompressing a file that has multiple extensions:
```csharp
name = name.Count(c => c == '.') > 1 && !Compress ? name.Remove(name.LastIndexOf('.')) : name;
```

These changes should improve the usability of the `SaveFileForCompression` method by ensuring that decompressed files with multiple extensions are saved with the correct file name.