### PR TITLE
Change GenericObject.GetMaxSkinInfluenceCount() to use boneWeights …

### DIFF
--- a/Switch_Toolbox_Library/Generics/GenericObject.cs
+++ b/Switch_Toolbox_Library/Generics/GenericObject.cs
@@ -69,7 +69,7 @@ namespace Toolbox.Library
 
         public byte GetMaxSkinInfluenceCount()
         {
-            return (byte)vertices.Max(t => t.boneIds.Count);
+            return (byte)vertices.Max(t => t.boneWeights.Count);
         }
 
         public Vector3 GetOrigin()


### PR DESCRIPTION
… instead of boneIds as the latter might not be initialized when the function is used.