### PR TITLE
Fix assimp not finding FBX's correct rootnode when the Armature is not the first RootNode child

### DIFF
--- a/Switch_Toolbox_Library/FileFormats/Assimp/Assimp.cs
+++ b/Switch_Toolbox_Library/FileFormats/Assimp/Assimp.cs
@@ -488,7 +488,15 @@ namespace Toolbox.Library
             if (node.HasChildren)
             {
                 foreach (Node child in node.Children)
-                    return GetSklRoot(child, boneNames);
+                {
+                    Node ChildNode = GetSklRoot(child, boneNames);
+                    if (ChildNode == null)
+                    {
+                        continue;
+                    }
+                    return ChildNode;
+                }
+                    
             }
             return null;
         }


### PR DESCRIPTION
This PR fixes toolbox not correctly importing bones if the Armature is not the first child in the RootNode node.
The code would terminate if the first index was not the armature and use the default RootNode instead of the correct root bone.