### PR TITLE
Support for changing existing mesh's skin count

### DIFF
--- a/File_Format_Library/GUI/BFRES/Shape/BfresShapeEditor.Designer.cs
+++ b/File_Format_Library/GUI/BFRES/Shape/BfresShapeEditor.Designer.cs
@@ -186,24 +186,14 @@
             // shapeVertexSkinCountUD
             // 
             this.shapeVertexSkinCountUD.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.shapeVertexSkinCountUD.Increment = new decimal(new int[] {
-            0,
-            0,
-            0,
-            0});
+            this.shapeVertexSkinCountUD.Increment = 1;
+            this.shapeVertexSkinCountUD.Value = 0;
             this.shapeVertexSkinCountUD.Location = new System.Drawing.Point(83, 59);
-            this.shapeVertexSkinCountUD.Maximum = new decimal(new int[] {
-            255,
-            0,
-            0,
-            0});
-            this.shapeVertexSkinCountUD.Minimum = new decimal(new int[] {
-            -2147483648,
-            0,
-            0,
-            -2147483648});
+            this.shapeVertexSkinCountUD.Maximum = 16;
+            this.shapeVertexSkinCountUD.Minimum = -2147483648;
+            this.shapeVertexSkinCountUD.ValueChanged += SkinCountUD_ValueChanged;
             this.shapeVertexSkinCountUD.Name = "shapeVertexSkinCountUD";
-            this.shapeVertexSkinCountUD.ReadOnly = true;
+            this.shapeVertexSkinCountUD.ReadOnly = false;
             this.shapeVertexSkinCountUD.Size = new System.Drawing.Size(121, 20);
             this.shapeVertexSkinCountUD.TabIndex = 39;
             // 

--- a/File_Format_Library/GUI/BFRES/Shape/BfresShapeEditor.cs
+++ b/File_Format_Library/GUI/BFRES/Shape/BfresShapeEditor.cs
@@ -42,7 +42,22 @@ namespace FirstPlugin
 
             activeShape = fshp;
 
-            shapeVertexSkinCountUD.Value = (decimal)fshp.VertexSkinCount;
+            // Disable skin count adjustment if no skinning
+            shapeVertexSkinCountUD.ReadOnly = fshp.VertexSkinCount == 0;
+
+            // Setup skin count adjustment
+            int lowestVertexSkinCount = fshp.GetLowestPossibleVertexSkinCount();
+            if (shapeVertexSkinCountUD.Minimum > lowestVertexSkinCount &&
+                shapeVertexSkinCountUD.Value > lowestVertexSkinCount)
+            {
+                shapeVertexSkinCountUD.Minimum = lowestVertexSkinCount;
+                shapeVertexSkinCountUD.Value = fshp.VertexSkinCount;
+            }
+            else
+            {
+                shapeVertexSkinCountUD.Value = fshp.VertexSkinCount;
+                shapeVertexSkinCountUD.Minimum = lowestVertexSkinCount;
+            }
 
             FMDL fmdl = fshp.GetParentModel();
 
@@ -67,14 +82,12 @@ namespace FirstPlugin
 
             if (fshp.VertexBufferU != null)
             {
-                vertexBufferSkinCountUD.Maximum = (decimal)fshp.VertexBufferU.VertexSkinCount;
-                vertexBufferSkinCountUD.Value = (decimal)fshp.VertexBufferU.VertexSkinCount;
+                vertexBufferSkinCountUD.Value = fshp.VertexBufferU.VertexSkinCount;
                 vertexBufferList1.LoadVertexBuffers(fshp, fshp.VertexBufferU);
             }
             else
             {
-                vertexBufferSkinCountUD.Maximum = (decimal)fshp.VertexBuffer.VertexSkinCount;
-                vertexBufferSkinCountUD.Value = (decimal)fshp.VertexBuffer.VertexSkinCount;
+                vertexBufferSkinCountUD.Value = fshp.VertexBuffer.VertexSkinCount;
                 vertexBufferList1.LoadVertexBuffers(fshp, fshp.VertexBuffer);
             }
 
@@ -291,6 +304,22 @@ namespace FirstPlugin
 
                 }
             }
+        }
+
+        private void SkinCountUD_ValueChanged(object sender, System.EventArgs e)
+        {
+            if (!(sender is NumericUpDownInt valueSelector))
+            { 
+                return; 
+            }
+
+            // Skip if already the same or 0
+            if (activeShape.VertexSkinCount == valueSelector.Value || valueSelector.Value == 0)
+            {
+                return;
+            }
+
+            activeShape.UpdateVertexSkinCount((int)valueSelector.Value);
         }
     }
 }


### PR DESCRIPTION
This PR adds support for **increasing** skin count.

To increase the skin count, just edit the skin count from the displayed box.
![image](https://github.com/KillzXGaming/Switch-Toolbox/assets/81146974/7beeb61d-096f-4aaf-a3df-6b75c407c792)


The maximum skin count is arbitrarily capped at 16.
The minimum skin count is calculated per mesh, usually the default imported value.

Increasing skin count is very useful, for example, if you have an earring model, it will usually only be weighted to 1 bone, thus a skin count of 1, but if you have a material that only supports, say, 3 skin count, being able to increase the skin count will save a lot of time (instead of using keep skin count).
 
Decreasing is not and can't be supported because (as far as I understand) it will cause information loss on the mesh.
To decrease skin count, use the limit total weights tool in blender in weight paint mode.

Tested Games:
- TOTK

@KillzXGaming 
I think more testing on other games might be needed.
But since this PR does not break anything else (hopefully) this could be merged.
