### PR TITLE
Fix/cafe bflyt set windowtype

### DIFF
--- a/File_Format_Library/FileFormats/Layout/CAFE/Panes/WND1.cs
+++ b/File_Format_Library/FileFormats/Layout/CAFE/Panes/WND1.cs
@@ -130,7 +130,14 @@ namespace LayoutBXLYT.Cafe
             set { }
         }
 
-        public WindowKind WindowKind { get; set; }
+        public WindowKind WindowKind
+        {
+            get { return (WindowKind)((_flag >> 2) & 3); }
+            set {
+                _flag = (byte)(_flag & ~(3 << 2));
+                _flag |= (byte)(((byte)value & 3) << 2);
+            }
+        }
 
         public bool NotDrawnContent
         {
@@ -243,8 +250,6 @@ namespace LayoutBXLYT.Cafe
             reader.ReadUInt16();//padding
             uint contentOffset = reader.ReadUInt32();
             uint frameOffsetTbl = reader.ReadUInt32();
-
-            WindowKind = (WindowKind)((_flag >> 2) & 3);
 
             reader.SeekBegin(pos + contentOffset);
             Content = new BxlytWindowContent(reader, header);

--- a/File_Format_Library/FileFormats/Layout/CTR/Panes/WND1.cs
+++ b/File_Format_Library/FileFormats/Layout/CTR/Panes/WND1.cs
@@ -26,7 +26,15 @@ namespace LayoutBXLYT.CTR
             set { }
         }
 
-        public WindowKind WindowKind { get; set; }
+        public WindowKind WindowKind
+        {
+            get { return (WindowKind)((_flag >> 2) & 3); }
+            set
+            {
+                _flag = (byte)(_flag & ~(3 << 2));
+                _flag |= (byte)(((byte)value & 3) << 2);
+            }
+        }
 
         public bool NotDrawnContent
         {
@@ -195,8 +203,6 @@ namespace LayoutBXLYT.CTR
             reader.ReadUInt16();//padding
             uint contentOffset = reader.ReadUInt32();
             uint frameOffsetTbl = reader.ReadUInt32();
-
-            WindowKind = (WindowKind)((_flag >> 2) & 3);
 
             reader.SeekBegin(pos + contentOffset);
             Content = new BxlytWindowContent(reader, header);

--- a/File_Format_Library/FileFormats/Layout/Rev/Panes/WND1.cs
+++ b/File_Format_Library/FileFormats/Layout/Rev/Panes/WND1.cs
@@ -26,7 +26,15 @@ namespace LayoutBXLYT.Revolution
             set { }
         }
 
-        public WindowKind WindowKind { get; set; }
+        public WindowKind WindowKind
+        {
+            get { return (WindowKind)((_flag >> 2) & 3); }
+            set
+            {
+                _flag = (byte)(_flag & ~(3 << 2));
+                _flag |= (byte)(((byte)value & 3) << 2);
+            }
+        }
 
         public bool NotDrawnContent
         {
@@ -195,8 +203,6 @@ namespace LayoutBXLYT.Revolution
             reader.ReadUInt16();//padding
             uint contentOffset = reader.ReadUInt32();
             uint frameOffsetTbl = reader.ReadUInt32();
-
-            WindowKind = (WindowKind)((_flag >> 2) & 3);
 
             reader.SeekBegin(pos + contentOffset);
             Content = new BxlytWindowContent(reader, header);


### PR DESCRIPTION
BFLYT Window Panes can be of three different types. While this type could be set from within the editor, this didn't actually propagate to the file when saved.

<img width="469" height="168" alt="image" src="https://github.com/user-attachments/assets/1587fa8d-73e6-4a34-b0c5-919d96b651af" />

Changes tested with Mario Kart 8 (Wii U)